### PR TITLE
Honor hidden columns and filtered rows

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ The `getCsvBlob` function allows you to generate a Blob with CSV data, providing
 ```typescript
 import {
   createColumnHelper,
-  getCoreRowModel,
+  getFilteredRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { getCsvBlob } from "tanstack-table-export-to-csv";
@@ -247,7 +247,7 @@ A handy utility function, `getHeaderNames`, helps in obtaining text versions of 
 ```typescript
 import {
   createColumnHelper,
-  getCoreRowModel,
+  getFilteredRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { getHeaderNames } from "tanstack-table-export-to-csv";
@@ -287,7 +287,7 @@ const columns = [
 const table = useReactTable({
   data,
   columns,
-  getCoreRowModel: getCoreRowModel(),
+  getFilteredRowModel: getFilteredRowModel(),
 });
 
 const headers = table

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export const getHeaderNames = (headers: Header<any, unknown>[]): string[] =>
 const getRowsData = (rows: Row<any>[]): string[][] => {
   return rows.map((row: Row<any>) => {
     const cells = row.getAllCells();
-    const cellsConent = cells.map((x) => x.getValue() as string);
+    const cellsConent = cells..filter((x) => x.column.getIsVisible()).map((x) => x.getValue() as string);
     return cellsConent;
   });
 };


### PR DESCRIPTION
Don't export hidden columns and filtered out rows. This makes exported table to contain exactly what the user sees